### PR TITLE
Fix: CSS Ligatures support (Fixes #2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ exports.decorateConfig = (config) => {
     cursorColor: CURSOR_COLOR,
     colors,
     termCSS: `
+      ${config.termCSS || ''}
       .cursor-node[focus=true]:not([moving]) {
         animation: blink 1s ease infinite;
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
 
   "name": "hyper-ayu-light",


### PR DESCRIPTION
The theme wasn't concatenating the termCSS property in the configuration thus preventing the rendering of the css ligatures